### PR TITLE
Add Login5 authentication support

### DIFF
--- a/librespot/core.py
+++ b/librespot/core.py
@@ -56,6 +56,17 @@ from librespot.proto import Keyexchange_pb2 as Keyexchange
 from librespot.proto import Metadata_pb2 as Metadata
 from librespot.proto import Playlist4External_pb2 as Playlist4External
 from librespot.proto.ExplicitContentPubsub_pb2 import UserAttributesUpdate
+try:
+    from librespot.proto.spotify.login5.v3 import Login5_pb2 as Login5
+    from librespot.proto.spotify.login5.v3 import ClientInfo_pb2 as Login5ClientInfo
+    from librespot.proto.spotify.login5.v3.credentials import Credentials_pb2 as Login5Credentials
+    LOGIN5_AVAILABLE = True
+except ImportError as e:
+    # Login5 protobuf files not available, will use fallback
+    LOGIN5_AVAILABLE = False
+    Login5 = None
+    Login5ClientInfo = None
+    Login5Credentials = None
 from librespot.structure import Closeable
 from librespot.structure import MessageListener
 from librespot.structure import RequestListener
@@ -823,6 +834,8 @@ class Session(Closeable, MessageListener, SubListener):
     __stored_str: str = ""
     __token_provider: typing.Union[TokenProvider, None]
     __user_attributes = {}
+    __login5_access_token: typing.Union[str, None] = None
+    __login5_token_expiry: typing.Union[int, None] = None
 
     def __init__(self, inner: Inner, address: str) -> None:
         self.__client = Session.create_client(inner.conf)
@@ -862,6 +875,10 @@ class Session(Closeable, MessageListener, SubListener):
 
         """
         self.__authenticate_partial(credential, False)
+        
+        # Try Login5 authentication for access token
+        self.__authenticate_login5(credential)
+        
         with self.__auth_lock:
             self.__mercury_client = MercuryClient(self)
             self.__token_provider = TokenProvider(self)
@@ -1279,6 +1296,64 @@ class Session(Closeable, MessageListener, SubListener):
     def __send_unchecked(self, cmd: bytes, payload: bytes) -> None:
         self.cipher_pair.send_encoded(self.connection, cmd, payload)
 
+    def __authenticate_login5(self, credential: Authentication.LoginCredentials) -> None:
+        """Authenticate using Login5 to get access token"""
+        if not LOGIN5_AVAILABLE:
+            self.logger.warning("Login5 protobuf files not available, skipping Login5 authentication")
+            return
+            
+        try:
+            # Build Login5 request
+            login5_request = Login5.LoginRequest()
+            
+            # Set client info
+            login5_request.client_info.client_id = "65b708073fc0480ea92a077233ca87bd"
+            login5_request.client_info.device_id = self.__inner.device_id
+            
+            # Set stored credential from APWelcome
+            if hasattr(self, '_Session__ap_welcome') and self.__ap_welcome:
+                stored_cred = Login5Credentials.StoredCredential()
+                stored_cred.username = self.__ap_welcome.canonical_username
+                stored_cred.data = self.__ap_welcome.reusable_auth_credentials
+                login5_request.stored_credential.CopyFrom(stored_cred)
+                
+                # Send Login5 request
+                login5_url = "https://login5.spotify.com/v3/login"
+                headers = {
+                    "Content-Type": "application/x-protobuf",
+                    "Accept": "application/x-protobuf"
+                }
+                
+                response = requests.post(
+                    login5_url,
+                    data=login5_request.SerializeToString(),
+                    headers=headers
+                )
+                
+                if response.status_code == 200:
+                    login5_response = Login5.LoginResponse()
+                    login5_response.ParseFromString(response.content)
+                    
+                    if login5_response.HasField('ok'):
+                        self.__login5_access_token = login5_response.ok.access_token
+                        self.__login5_token_expiry = int(time.time()) + login5_response.ok.access_token_expires_in
+                        self.logger.info("Login5 authentication successful, got access token")
+                    else:
+                        self.logger.warning("Login5 authentication failed: {}".format(login5_response.error))
+                else:
+                    self.logger.warning("Login5 request failed with status: {}".format(response.status_code))
+        except Exception as e:
+            self.logger.warning("Failed to authenticate with Login5: {}".format(e))
+    
+    def get_login5_token(self) -> typing.Union[str, None]:
+        """Get the Login5 access token if available and not expired"""
+        if self.__login5_access_token and self.__login5_token_expiry:
+            if int(time.time()) < self.__login5_token_expiry - 60:  # 60 second buffer
+                return self.__login5_access_token
+            else:
+                self.logger.debug("Login5 token expired, need to re-authenticate")
+        return None
+    
     def __wait_auth_lock(self) -> None:
         if self.__closing and self.connection is None:
             self.logger.debug("Connection was broken while closing.")
@@ -2171,6 +2246,16 @@ class TokenProvider:
         scopes = list(scopes)
         if len(scopes) == 0:
             raise RuntimeError("The token doesn't have any scope")
+        
+        # Try to use Login5 token first
+        login5_token = self._session.get_login5_token()
+        if login5_token:
+            # Create a StoredToken-compatible object using Login5 token
+            login5_stored_token = TokenProvider.Login5StoredToken(login5_token, scopes)
+            self.logger.debug("Using Login5 access token for scopes: {}".format(scopes))
+            return login5_stored_token
+            
+        # Fallback to existing token logic
         token = self.find_token_with_all_scopes(scopes)
         if token is not None:
             if token.expired():
@@ -2180,15 +2265,42 @@ class TokenProvider:
         self.logger.debug(
             "Token expired or not suitable, requesting again. scopes: {}, old_token: {}"
             .format(scopes, token))
-        response = self._session.mercury().send_sync_json(
-            MercuryRequests.request_token(self._session.device_id(),
-                                          ",".join(scopes)))
-        token = TokenProvider.StoredToken(response)
-        self.logger.debug(
-            "Updated token successfully! scopes: {}, new_token: {}".format(
-                scopes, token))
-        self.__tokens.append(token)
-        return token
+        
+        # Try keymaster endpoint as fallback (deprecated)
+        try:
+            response = self._session.mercury().send_sync_json(
+                MercuryRequests.request_token(self._session.device_id(),
+                                              ",".join(scopes)))
+            token = TokenProvider.StoredToken(response)
+            self.logger.debug(
+                "Updated token successfully! scopes: {}, new_token: {}".format(
+                    scopes, token))
+            self.__tokens.append(token)
+            return token
+        except Exception as e:
+            self.logger.warning("Failed to get token from keymaster endpoint: {}".format(e))
+            raise RuntimeError("Unable to obtain access token")
+
+    class Login5StoredToken:
+        """StoredToken-compatible wrapper for Login5 access tokens"""
+        access_token: str
+        scopes: typing.List[str]
+        
+        def __init__(self, access_token: str, scopes: typing.List[str]):
+            self.access_token = access_token
+            self.scopes = scopes
+        
+        def expired(self) -> bool:
+            """Login5 tokens are managed by Session, so delegate expiry check"""
+            return False  # Session handles expiry
+        
+        def has_scope(self, scope: str) -> bool:
+            """Login5 tokens are general-purpose, assume they have all scopes"""
+            return True
+        
+        def has_scopes(self, sc: typing.List[str]) -> bool:
+            """Login5 tokens are general-purpose, assume they have all scopes"""
+            return True
 
     class StoredToken:
         """ """

--- a/librespot/mercury.py
+++ b/librespot/mercury.py
@@ -301,6 +301,8 @@ class MercuryRequests:
 
     @staticmethod
     def request_token(device_id, scope):
+        # NOTE: This method is deprecated in favor of Login5 authentication
+        # Keeping for backward compatibility but should use Session.get_login5_token()
         return JsonMercuryRequest(
             RawMercuryRequest.get(
                 "hm://keymaster/token/authenticated?scope={}&client_id={}&device_id={}"

--- a/librespot/proto/spotify/login5/v3/Login5_pb2.py
+++ b/librespot/proto/spotify/login5/v3/Login5_pb2.py
@@ -7,19 +7,19 @@ from google.protobuf import message as _message
 from google.protobuf import reflection as _reflection
 from google.protobuf import symbol_database as _symbol_database
 from google.protobuf.internal import enum_type_wrapper
-from spotify.login5.v3 import \
-    client_info_pb2 as spotify_dot_login5_dot_v3_dot_client__info__pb2
-from spotify.login5.v3 import \
-    user_info_pb2 as spotify_dot_login5_dot_v3_dot_user__info__pb2
-from spotify.login5.v3.challenges import \
-    code_pb2 as spotify_dot_login5_dot_v3_dot_challenges_dot_code__pb2
-from spotify.login5.v3.challenges import \
-    hashcash_pb2 as spotify_dot_login5_dot_v3_dot_challenges_dot_hashcash__pb2
-from spotify.login5.v3.credentials import \
-    credentials_pb2 as \
+from librespot.proto.spotify.login5.v3 import \
+    ClientInfo_pb2 as spotify_dot_login5_dot_v3_dot_client__info__pb2
+from librespot.proto.spotify.login5.v3 import \
+    UserInfo_pb2 as spotify_dot_login5_dot_v3_dot_user__info__pb2
+from librespot.proto.spotify.login5.v3.challenges import \
+    Code_pb2 as spotify_dot_login5_dot_v3_dot_challenges_dot_code__pb2
+from librespot.proto.spotify.login5.v3.challenges import \
+    Hashcash_pb2 as spotify_dot_login5_dot_v3_dot_challenges_dot_hashcash__pb2
+from librespot.proto.spotify.login5.v3.credentials import \
+    Credentials_pb2 as \
     spotify_dot_login5_dot_v3_dot_credentials_dot_credentials__pb2
-from spotify.login5.v3.identifiers import \
-    identifiers_pb2 as \
+from librespot.proto.spotify.login5.v3.identifiers import \
+    Identifiers as \
     spotify_dot_login5_dot_v3_dot_identifiers_dot_identifiers__pb2
 
 # @@protoc_insertion_point(imports)

--- a/tests/test_login5.py
+++ b/tests/test_login5.py
@@ -1,0 +1,115 @@
+#!/usr/bin/env python3
+"""
+Test script to verify Login5 authentication is working
+"""
+
+import logging
+import sys
+import os
+from librespot.core import Session
+
+# Enable debug logging to see what's happening
+logging.basicConfig(level=logging.DEBUG, format='%(asctime)s - %(name)s - %(levelname)s - %(message)s')
+
+def test_with_stored_credentials():
+    """Test using stored credentials (if available)"""
+    print("=== Testing with stored credentials ===")
+    
+    try:
+        if os.path.exists("credentials.json"):
+            session = Session.Builder().stored_file("credentials.json").create()
+            print(f"✓ Successfully authenticated as: {session.username()}")
+            
+            # Test token retrieval
+            token_provider = session.tokens()
+            try:
+                token = token_provider.get("playlist-read")
+                print(f"✓ Successfully got playlist-read token: {token[:20]}...")
+                
+                # Check if Login5 token is available
+                login5_token = session.get_login5_token()
+                if login5_token:
+                    print(f"✓ Login5 token available: {login5_token[:20]}...")
+                else:
+                    print("⚠ Login5 token not available, using fallback")
+                
+                session.close()
+                return True
+            except Exception as e:
+                print(f"✗ Token retrieval failed: {e}")
+                session.close()
+                return False
+        else:
+            print("⚠ No credentials.json file found")
+            return False
+            
+    except Exception as e:
+        print(f"✗ Authentication failed: {e}")
+        return False
+
+def test_with_username_password():
+    """Test with username/password (requires user input)"""
+    print("\n=== Testing with username/password ===")
+    
+    username = input("Enter Spotify username (or press Enter to skip): ").strip()
+    if not username:
+        print("Skipping username/password test")
+        return False
+        
+    password = input("Enter Spotify password: ").strip()
+    if not password:
+        print("Skipping username/password test")
+        return False
+    
+    try:
+        session = Session.Builder().user_pass(username, password).create()
+        print(f"✓ Successfully authenticated as: {session.username()}")
+        
+        # Test token retrieval
+        token_provider = session.tokens()
+        try:
+            token = token_provider.get("playlist-read")
+            print(f"✓ Successfully got playlist-read token: {token[:20]}...")
+            
+            # Check if Login5 token is available
+            login5_token = session.get_login5_token()
+            if login5_token:
+                print(f"✓ Login5 token available: {login5_token[:20]}...")
+            else:
+                print("⚠ Login5 token not available, using fallback")
+            
+            session.close()
+            return True
+        except Exception as e:
+            print(f"✗ Token retrieval failed: {e}")
+            session.close()
+            return False
+            
+    except Exception as e:
+        print(f"✗ Authentication failed: {e}")
+        return False
+
+def main():
+    print("Testing Login5 Authentication Implementation")
+    print("=" * 50)
+    
+    # Test 1: Stored credentials
+    stored_success = test_with_stored_credentials()
+    
+    # Test 2: Username/password (optional)
+    manual_success = test_with_username_password()
+    
+    print("\n" + "=" * 50)
+    print("Test Results:")
+    print(f"Stored credentials: {'✓ PASS' if stored_success else '✗ FAIL'}")
+    print(f"Username/password: {'✓ PASS' if manual_success else '✗ FAIL'}")
+    
+    if stored_success or manual_success:
+        print("\n🎉 Login5 authentication is working!")
+        return 0
+    else:
+        print("\n⚠ Could not test authentication - no valid credentials")
+        return 1
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_zeroconf_login5.py
+++ b/tests/test_zeroconf_login5.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python3
+"""
+Test script using Zeroconf to verify Login5 authentication
+This method doesn't require Spotify Premium
+"""
+
+import logging
+import time
+import pathlib
+from librespot.zeroconf import ZeroconfServer
+
+# Enable debug logging
+logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(name)s - %(levelname)s - %(message)s')
+
+def test_zeroconf_login5():
+    """Test Login5 using Zeroconf authentication"""
+    print("=== Testing Login5 with Zeroconf ===")
+    print("1. Open Spotify on your phone/computer")
+    print("2. Look for 'librespot-spotizerr' in Spotify Connect devices")
+    print("3. Transfer playback to it")
+    print("4. Wait for credentials to be stored...")
+    print("\nWaiting for Spotify Connect transfer...")
+    
+    zs = ZeroconfServer.Builder().create()
+    
+    start_time = time.time()
+    timeout = 60  # 60 seconds timeout
+    
+    while True:
+        time.sleep(1)
+        elapsed = time.time() - start_time
+        
+        if elapsed > timeout:
+            print(f"\n⚠ Timeout after {timeout} seconds")
+            print("Make sure you:")
+            print("- Have Spotify open on another device")
+            print("- Can see 'librespot-spotizerr' in Spotify Connect")
+            print("- Transfer playback to it")
+            return False
+            
+        if zs._ZeroconfServer__session:
+            session = zs._ZeroconfServer__session
+            print(f"\n✓ Got session for user: {session.username()}")
+            
+            # Test token retrieval
+            try:
+                token_provider = session.tokens()
+                token = token_provider.get("playlist-read")
+                print(f"✓ Got playlist-read token: {token[:20]}...")
+                
+                # Test Login5 token
+                login5_token = session.get_login5_token()
+                if login5_token:
+                    print(f"✓ Login5 token available: {login5_token[:20]}...")
+                else:
+                    print("⚠ Login5 token not available, using fallback")
+                
+                # Check if credentials were saved
+                if pathlib.Path("credentials.json").exists():
+                    print("✓ Credentials saved to credentials.json")
+                    print("\nYou can now use the stored credentials for future tests!")
+                    return True
+                else:
+                    print("⚠ Credentials not saved")
+                    return True
+                    
+            except Exception as e:
+                print(f"✗ Token test failed: {e}")
+                return False
+
+def main():
+    print("Zeroconf Login5 Test")
+    print("=" * 30)
+    
+    success = test_zeroconf_login5()
+    
+    print("\n" + "=" * 30)
+    if success:
+        print("🎉 Zeroconf Login5 test completed successfully!")
+        return 0
+    else:
+        print("⚠ Zeroconf test failed or timed out")
+        return 1
+
+if __name__ == "__main__":
+    import sys
+    sys.exit(main())


### PR DESCRIPTION
Hi @Xoconoch 
Related with https://github.com/Xoconoch/spotizerr/issues/239
This MR is full vibe coding, I don't expect to be merged but maybe it can help on how to implement the new auth method.
With the tests in the PR I've managed to authenticate

```
python test_zeroconf_login5.py                   
Zeroconf Login5 Test
==============================
=== Testing Login5 with Zeroconf ===
1. Open Spotify on your phone/computer
2. Look for 'librespot-spotizerr' in Spotify Connect devices
3. Transfer playback to it
4. Wait for credentials to be stored...

Waiting for Spotify Connect transfer...
2025-08-13 19:44:29,212 - Librespot:Session - INFO - Created new session! device_id: xxx, ap: ap-gew1.spotify.com:4070
2025-08-13 19:44:30,260 - Librespot:Session - INFO - Connection successfully!
2025-08-13 19:44:30,340 - Librespot:Session - INFO - Session.Receiver started
2025-08-13 19:44:30,495 - Librespot:Session - INFO - Login5 authentication successful, got access token
2025-08-13 19:44:30,605 - Librespot:Session - INFO - Skipping 02
2025-08-13 19:44:30,606 - Librespot:Session - INFO - Received license_version: 0
2025-08-13 19:44:30,607 - Librespot:Session - INFO - Received country_code: ES
2025-08-13 19:44:30,622 - Librespot:Session - INFO - Skipping 1f
2025-08-13 19:44:30,623 - Librespot:Session - INFO - Skipping 69
2025-08-13 19:44:30,714 - Librespot:Session - INFO - Skipping unknown command cmd: 0x75, payload: b'\x00\x00\x01'
2025-08-13 19:44:30,715 - Librespot:Session - INFO - Authenticated as 3...

✓ Got session for user: ...
✓ Got playlist-read token: ...
✓ Login5 token available: ...
✓ Credentials saved to credentials.json

You can now use the stored credentials for future tests!

==============================
🎉 Zeroconf Login5 test completed successfully!
```