### PR TITLE
Cleanup old login method

### DIFF
--- a/librespot/core.py
+++ b/librespot/core.py
@@ -205,7 +205,7 @@ class ApiClient(Closeable):
         proto_req = ClientToken.ClientTokenRequest(
             request_type=ClientToken.ClientTokenRequestType.REQUEST_CLIENT_DATA_REQUEST,
             client_data=ClientToken.ClientDataRequest(
-                client_id="65b708073fc0480ea92a077233ca87bd",
+                client_id=Session.CLIENT_ID,
                 client_version=Version.version_name,
                 connectivity_sdk_data=Connectivity.ConnectivitySdkData(
                     device_id=self.__session.device_id(),
@@ -783,6 +783,7 @@ class MessageType(enum.Enum):
 
 class Session(Closeable, MessageListener, SubListener):
     """ """
+    CLIENT_ID = "65b708073fc0480ea92a077233ca87bd"  # Spotify client ID for librespot
     cipher_pair: typing.Union[CipherPair, None]
     country_code: str = "EN"
     connection: typing.Union[ConnectionHolder, None]
@@ -1294,7 +1295,7 @@ class Session(Closeable, MessageListener, SubListener):
             login5_request = Login5.LoginRequest()
             
             # Set client info
-            login5_request.client_info.client_id = "65b708073fc0480ea92a077233ca87bd"
+            login5_request.client_info.client_id = Session.CLIENT_ID
             login5_request.client_info.device_id = self.__inner.device_id
             
             # Set stored credential from APWelcome

--- a/librespot/core.py
+++ b/librespot/core.py
@@ -1989,7 +1989,7 @@ class Session(Closeable, MessageListener, SubListener):
                             format(util.bytes_to_hex(packet.cmd),
                                    packet.payload))
                         continue
-                except (RuntimeError, ConnectionResetError) as ex:
+                except (RuntimeError, ConnectionResetError, OSError) as ex:
                     if self.__running:
                         self.__session.logger.fatal(
                             "Failed reading packet! {}".format(ex))

--- a/librespot/core.py
+++ b/librespot/core.py
@@ -56,7 +56,6 @@ from librespot.proto import Metadata_pb2 as Metadata
 from librespot.proto import Playlist4External_pb2 as Playlist4External
 from librespot.proto.ExplicitContentPubsub_pb2 import UserAttributesUpdate
 from librespot.proto.spotify.login5.v3 import Login5_pb2 as Login5
-from librespot.proto.spotify.login5.v3 import ClientInfo_pb2 as Login5ClientInfo
 from librespot.proto.spotify.login5.v3.credentials import Credentials_pb2 as Login5Credentials
 from librespot.structure import Closeable
 from librespot.structure import MessageListener

--- a/librespot/mercury.py
+++ b/librespot/mercury.py
@@ -299,15 +299,6 @@ class MercuryRequests:
         @TODO implement function
         """
 
-    @staticmethod
-    def request_token(device_id, scope):
-        # NOTE: This method is deprecated in favor of Login5 authentication
-        # Keeping for backward compatibility but should use Session.get_login5_token()
-        return JsonMercuryRequest(
-            RawMercuryRequest.get(
-                "hm://keymaster/token/authenticated?scope={}&client_id={}&device_id={}"
-                .format(scope, MercuryRequests.keymaster_client_id,
-                        device_id)))
 
 
 class RawMercuryRequest:

--- a/tests/test_login5.py
+++ b/tests/test_login5.py
@@ -31,7 +31,7 @@ def test_with_stored_credentials():
                 if login5_token:
                     print(f"✓ Login5 token available: {login5_token[:20]}...")
                 else:
-                    print("⚠ Login5 token not available, using fallback")
+                    print("⚠ Login5 token not available")
                 
                 session.close()
                 return True
@@ -76,7 +76,7 @@ def test_with_username_password():
             if login5_token:
                 print(f"✓ Login5 token available: {login5_token[:20]}...")
             else:
-                print("⚠ Login5 token not available, using fallback")
+                print("⚠ Login5 token not available")
             
             session.close()
             return True

--- a/tests/test_login5.py
+++ b/tests/test_login5.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 """
-Test script to verify Login5 authentication is working
+Test script to verify Login5 authentication using stored credentials
 """
 
 import logging
@@ -47,68 +47,26 @@ def test_with_stored_credentials():
         print(f"✗ Authentication failed: {e}")
         return False
 
-def test_with_username_password():
-    """Test with username/password (requires user input)"""
-    print("\n=== Testing with username/password ===")
-    
-    username = input("Enter Spotify username (or press Enter to skip): ").strip()
-    if not username:
-        print("Skipping username/password test")
-        return False
-        
-    password = input("Enter Spotify password: ").strip()
-    if not password:
-        print("Skipping username/password test")
-        return False
-    
-    try:
-        session = Session.Builder().user_pass(username, password).create()
-        print(f"✓ Successfully authenticated as: {session.username()}")
-        
-        # Test token retrieval
-        token_provider = session.tokens()
-        try:
-            token = token_provider.get("playlist-read")
-            print(f"✓ Successfully got playlist-read token: {token[:20]}...")
-            
-            # Check if Login5 token is available
-            login5_token = session.get_login5_token()
-            if login5_token:
-                print(f"✓ Login5 token available: {login5_token[:20]}...")
-            else:
-                print("⚠ Login5 token not available")
-            
-            session.close()
-            return True
-        except Exception as e:
-            print(f"✗ Token retrieval failed: {e}")
-            session.close()
-            return False
-            
-    except Exception as e:
-        print(f"✗ Authentication failed: {e}")
-        return False
-
 def main():
     print("Testing Login5 Authentication Implementation")
     print("=" * 50)
     
-    # Test 1: Stored credentials
+    # Test with stored credentials
     stored_success = test_with_stored_credentials()
     
-    # Test 2: Username/password (optional)
-    manual_success = test_with_username_password()
+    # Note: Username/password authentication has been deprecated by Spotify
+    # and is no longer supported. Use stored credentials or OAuth flow instead.
     
     print("\n" + "=" * 50)
     print("Test Results:")
-    print(f"Stored credentials: {'✓ PASS' if stored_success else '✗ FAIL'}")
-    print(f"Username/password: {'✓ PASS' if manual_success else '✗ FAIL'}")
+    print(f"Stored credentials: {'✓ PASS' if stored_success else '✗ FAIL or NO CREDENTIALS'}")
     
-    if stored_success or manual_success:
+    if stored_success:
         print("\n🎉 Login5 authentication is working!")
         return 0
     else:
-        print("\n⚠ Could not test authentication - no valid credentials")
+        print("\n⚠ Could not test authentication - no valid credentials.json file found")
+        print("  Please authenticate using OAuth or other supported methods first.")
         return 1
 
 if __name__ == "__main__":

--- a/tests/test_zeroconf_login5.py
+++ b/tests/test_zeroconf_login5.py
@@ -53,7 +53,7 @@ def test_zeroconf_login5():
                 if login5_token:
                     print(f"✓ Login5 token available: {login5_token[:20]}...")
                 else:
-                    print("⚠ Login5 token not available, using fallback")
+                    print("⚠ Login5 token not available")
                 
                 # Check if credentials were saved
                 if pathlib.Path("credentials.json").exists():

--- a/tests/test_zeroconf_login5.py
+++ b/tests/test_zeroconf_login5.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python3
 """
-Test script using Zeroconf to verify Login5 authentication
-This method doesn't require Spotify Premium
+Test script using Zeroconf/Spotify Connect to verify Login5 authentication
 """
 
 import logging


### PR DESCRIPTION
Hi,
Follow up from https://github.com/Xoconoch/librespot-spotizerr/pull/6
Cleaning up the old login method and simplify tests

Test looks good after the changes:
```
Zeroconf Login5 Test
==============================
=== Testing Login5 with Zeroconf ===
1. Open Spotify on your phone/computer
2. Look for 'librespot-spotizerr' in Spotify Connect devices
3. Transfer playback to it
4. Wait for credentials to be stored...

Waiting for Spotify Connect transfer...
2025-08-14 08:00:46,891 - Librespot:Session - INFO - Created new session! device_id: XXX, ap: ap-gew4.spotify.com:443
2025-08-14 08:00:47,951 - Librespot:Session - INFO - Connection successfully!
2025-08-14 08:00:48,029 - Librespot:Session - INFO - Session.Receiver started
2025-08-14 08:00:48,175 - Librespot:Session - INFO - Login5 authentication successful, got access token
2025-08-14 08:00:48,284 - Librespot:Session - INFO - Skipping 02
2025-08-14 08:00:48,285 - Librespot:Session - INFO - Received license_version: 0
2025-08-14 08:00:48,286 - Librespot:Session - INFO - Received country_code: ES
2025-08-14 08:00:48,303 - Librespot:Session - INFO - Skipping 1f
2025-08-14 08:00:48,303 - Librespot:Session - INFO - Skipping 69
2025-08-14 08:00:48,398 - Librespot:Session - INFO - Authenticated as XXX!
2025-08-14 08:00:48,429 - Librespot:Session - INFO - Skipping unknown command cmd: 0x75, payload: b'\x00\x00\x01'

✓ Got session for user: XXX
✓ Got playlist-read token: XXX...
✓ Login5 token available: XXX...
✓ Credentials saved to credentials.json

You can now use the stored credentials for future tests!

==============================
🎉 Zeroconf Login5 test completed successfully!
```